### PR TITLE
Add Support For Profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # WP Sync DB CLI
+
 An addon for [WP Sync DB](https://github.com/slang800/wp-sync-db) that allows you to execute migrations using a function call or via WP-CLI

--- a/class/command.php
+++ b/class/command.php
@@ -115,6 +115,28 @@ class WPSDBCLI extends WP_CLI_Command {
 		return;
 	}
 
+	/**
+	 * Echo out the DB token. For use in automation.
+	 *
+	 * ## EXAMPLES
+	 *
+	 * 	wp wpsdb connection-info
+	 *
+	 * @since 1.0
+	 * @subcommand connection-info
+	 */
+	public function connection_info( $args, $assoc_args ) {
+		$result = wpsdb_cli_connection_info();
+
+		if ( $result ) {
+			WP_CLI::log( $result );
+			return;
+		}
+
+		WP_CLI::warning( $result->get_error_message() );
+		return;
+	}
+
 }
 
 WP_CLI::add_command( 'wpsdb', 'WPSDBCLI' );

--- a/class/command.php
+++ b/class/command.php
@@ -129,7 +129,7 @@ class WPSDBCLI extends WP_CLI_Command {
 		$result = wpsdb_cli_connection_info();
 
 		if ( $result ) {
-			WP_CLI::log( $result );
+			print( $result );
 			return;
 		}
 

--- a/class/command.php
+++ b/class/command.php
@@ -66,37 +66,32 @@ class WPSDBCLI extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 * 	wp wpsdb create-profile Staging --remote-wordpress https://wordpress.example \
+	 * # Setup a profile with the defaults called Staging.
+	 * $ wp wpsdb create-profile Staging --remote-wordpress https://wordpress.example \
 	 * 																	--token CUOu2t5kaVienGLUxAGhN4bvWh1FXqJA
 	 *
-	 *  Setup a profile with the defaults called Staging.
-	 *
-	 *
-	 * 	wp wpsdb create-profile Staging --remote-wordpress https://wordpress.example \
+	 * # Setup a profile with the defaults called Staging that only migrates the wp_posts table.
+	 * $ wp wpsdb create-profile Staging --remote-wordpress https://wordpress.example \
 	 * 																	--token CUOu2t5kaVienGLUxAGhN4bvWh1FXqJA \
 	 *                  								 --migrate-tables=wp_posts
 	 *
-	 *  Setup a profile with the defaults called Staging that only migrates the wp_posts table.
-	 *
-	 *
-	 * 	wp wpsdb create-profile Staging --remote-wordpress https://wordpress.example \
+	 * # Setup a profile with the defaults called Staging that excludes WordPress page post types.
+	 * $ wp wpsdb create-profile Staging --remote-wordpress https://wordpress.example \
 	 * 																	--token CUOu2t5kaVienGLUxAGhN4bvWh1FXqJA \
 	 *                  								 --exclude-post-types=page
 	 *
-	 *  Setup a profile with the defaults called Staging that excludes WordPress page post types.
-	 *
-	 *
-	 * 	wp wpsdb create-profile Staging --remote-wordpress https://wordpress.example \
+	 * # Setup a profile with the defaults called Staging that creates backups when migrations are run.
+	 * 	$ wp wpsdb create-profile Staging --remote-wordpress https://wordpress.example \
 	 * 																	--token CUOu2t5kaVienGLUxAGhN4bvWh1FXqJA \
 	 *                  								 --create_backup=true
-	 *
-	 *  Setup a profile with the defaults called Staging that creates backups when migrations are run.
 	 *
 	 * @synopsis <profile>
 	 *
 	 * @since 1.0
-	 * @subcommand create-profile
 	 */
+	 /**
+ 		* @subcommand create-profile
+ 		*/
 	public function create_profile( $args, $assoc_args ) {
 		$name = $args[0];
 

--- a/class/command.php
+++ b/class/command.php
@@ -55,7 +55,16 @@ class WPSDBCLI extends WP_CLI_Command {
 		* @subcommand create-profile
 		*/
 	public function create_profile( $args, $assoc_args ) {
-		WP_CLI::success( __( 'Profile created.', 'wp-sync-db-cli' ) );
+		$name = $args[0];
+		$result = wpdsb_create_profile( $name, $assoc_args );
+
+		if ( true === $result ) {
+			WP_CLI::success( __( 'Profile created.', 'wp-sync-db-cli' ) );
+			return;
+		}
+
+		WP_CLI::error( $result->get_error_message() );
+		return;
 	}
 
 }

--- a/class/command.php
+++ b/class/command.php
@@ -56,6 +56,15 @@ class WPSDBCLI extends WP_CLI_Command {
 		*/
 	public function create_profile( $args, $assoc_args ) {
 		$name = $args[0];
+
+		if ( ! isset( $assoc_args['remote_wordpress'] ) || ! isset( $assoc_args['token'] ) ) {
+			$error_lines = array();
+			$error_lines[] = __( 'Connection information to remote WordPress installation for migration is required.' );
+			$error_lines[] = __( 'Set with --remote_wordpress and --token flag.' );
+			WP_CLI::error_multi_line( $error_lines );
+			return;
+		}
+
 		$result = wpdsb_create_profile( $name, $assoc_args );
 
 		if ( true === $result ) {

--- a/class/command.php
+++ b/class/command.php
@@ -57,10 +57,10 @@ class WPSDBCLI extends WP_CLI_Command {
 	public function create_profile( $args, $assoc_args ) {
 		$name = $args[0];
 
-		if ( ! isset( $assoc_args['remote_wordpress'] ) || ! isset( $assoc_args['token'] ) ) {
+		if ( ! isset( $assoc_args['remote-wordpress'] ) || ! isset( $assoc_args['token'] ) ) {
 			$error_lines = array();
 			$error_lines[] = __( 'Connection information to remote WordPress installation for migration is required.' );
-			$error_lines[] = __( 'Set with --remote_wordpress and --token flag.' );
+			$error_lines[] = __( 'Set with --remote-wordpress and --token flag.' );
 			WP_CLI::error_multi_line( $error_lines );
 			return;
 		}
@@ -68,7 +68,7 @@ class WPSDBCLI extends WP_CLI_Command {
 		$result = wpdsb_create_profile( $name, $assoc_args );
 
 		if ( true === $result ) {
-			WP_CLI::success( __( 'Profile created.', 'wp-sync-db-cli' ) );
+			WP_CLI::success( sprintf( __( 'Profile %1$s created.', 'wp-sync-db-cli' ), $name ) );
 			return;
 		}
 

--- a/class/command.php
+++ b/class/command.php
@@ -106,7 +106,7 @@ class WPSDBCLI extends WP_CLI_Command {
 		$result = wpdsb_create_profile( $name, $assoc_args );
 
 		if ( true === $result ) {
-			WP_CLI::success( sprintf( __( 'Profile %1$s created.', 'wp-sync-db-cli' ), $name ) );
+			WP_CLI::success( sprintf( __( 'Profile \'%1$s\' created.', 'wp-sync-db-cli' ), $name ) );
 			return;
 		}
 

--- a/class/command.php
+++ b/class/command.php
@@ -88,6 +88,7 @@ class WPSDBCLI extends WP_CLI_Command {
 	 * @synopsis <profile>
 	 *
 	 * @since 1.0
+	 * TODO: Incorporate the above into a proper help message.
 	 */
 	 /**
  		* @subcommand create-profile

--- a/class/command.php
+++ b/class/command.php
@@ -35,6 +35,29 @@ class WPSDBCLI extends WP_CLI_Command {
 		return;
 	}
 
+	/**
+	 * Create a profile
+	 *
+	 * ## OPTIONS
+	 *
+	 * <profile>
+	 * : ID of the profile to use for the migration.
+	 *
+	 * ## EXAMPLES
+	 *
+	 * 	wp wpsdb create-profile 1
+	 *
+	 * @synopsis <profile>
+	 *
+	 * @since 1.0
+	 */
+	/**
+		* @subcommand create-profile
+		*/
+	public function create_profile( $args, $assoc_args ) {
+		WP_CLI::success( __( 'Profile created.', 'wp-sync-db-cli' ) );
+	}
+
 }
 
 WP_CLI::add_command( 'wpsdb', 'WPSDBCLI' );

--- a/class/command.php
+++ b/class/command.php
@@ -41,19 +41,64 @@ class WPSDBCLI extends WP_CLI_Command {
 	 * ## OPTIONS
 	 *
 	 * <profile>
-	 * : ID of the profile to use for the migration.
+	 * : Name of the new profile to create
+	 *
+	 * [--remote-wordpress=<value>]
+	 * : Remote WordPress location to migrate database from.
+	 *
+	 * This is the first part the whole token you are told to copy from
+	 * the /wp-admin/ backend of Migrate DB under Settings, before the newline.
+	 *
+	 * [--token=<value>]
+	 * : Token from WordPress location to migrate database from.
+	 *
+	 * This is the second part the whole token you are told to copy from
+	 * the /wp-admin/ backend of Migrate DB under Settings, after the newline.
+	 *
+	 * [--migrate-tables=<CSV of tables to migrate>]
+	 * : Comma separated list of tables to migrate from the remote WordPress to locally.
+	 *
+	 * If you set this to `outlandish` it will migrate the tables we would typically expect from WordPress.
+	 *
+	 * [--exclude-post-types=<CSV of tables to migrate>]
+	 * : Comma separated list of post types to exclude from migrate from the remote WordPress to locally.
+	 *
+	 * [--<WP-Migrate-Profile-Option-As-Kebab-Case>=<true|false>]
+	 * : Set any Migrate DB option in this profile.
 	 *
 	 * ## EXAMPLES
 	 *
-	 * 	wp wpsdb create-profile 1
+	 * 	wp wpsdb create-profile Staging --remote-wordpress https://wordpress.example \
+	 * 																	--token CUOu2t5kaVienGLUxAGhN4bvWh1FXqJA
+	 *
+	 *  Setup a profile with the defaults called Staging.
+	 *
+	 *
+	 * 	wp wpsdb create-profile Staging --remote-wordpress https://wordpress.example \
+	 * 																	--token CUOu2t5kaVienGLUxAGhN4bvWh1FXqJA \
+	 *                  								 --migrate-tables=wp_posts
+	 *
+	 *  Setup a profile with the defaults called Staging that only migrates the wp_posts table.
+	 *
+	 *
+	 * 	wp wpsdb create-profile Staging --remote-wordpress https://wordpress.example \
+	 * 																	--token CUOu2t5kaVienGLUxAGhN4bvWh1FXqJA \
+	 *                  								 --exclude-post-types=page
+	 *
+	 *  Setup a profile with the defaults called Staging that excludes WordPress page post types.
+	 *
+	 *
+	 * 	wp wpsdb create-profile Staging --remote-wordpress https://wordpress.example \
+	 * 																	--token CUOu2t5kaVienGLUxAGhN4bvWh1FXqJA \
+	 *                  								 --create_backup=true
+	 *
+	 *  Setup a profile with the defaults called Staging that creates backups when migrations are run.
 	 *
 	 * @synopsis <profile>
 	 *
 	 * @since 1.0
+	 * @subcommand create-profile
 	 */
-	/**
-		* @subcommand create-profile
-		*/
 	public function create_profile( $args, $assoc_args ) {
 		$name = $args[0];
 

--- a/class/command.php
+++ b/class/command.php
@@ -58,8 +58,6 @@ class WPSDBCLI extends WP_CLI_Command {
 	 * [--migrate-tables=<CSV of tables to migrate>]
 	 * : Comma separated list of tables to migrate from the remote WordPress to locally.
 	 *
-	 * If you set this to `outlandish` it will migrate the tables we would typically expect from WordPress.
-	 *
 	 * [--exclude-post-types=<CSV of tables to migrate>]
 	 * : Comma separated list of post types to exclude from migrate from the remote WordPress to locally.
 	 *

--- a/class/wpsdb-cli.php
+++ b/class/wpsdb-cli.php
@@ -47,6 +47,16 @@ class WPSDB_CLI extends WPSDB_Addon {
 		return $result;
 	}
 
+	function cli_connection_info( ) {
+		$wpsdb_settings = get_option( 'wpsdb_settings' );
+
+		if ( $wpsdb_settings['key'] ) {
+			return $wpsdb_settings['key'];
+		} else {
+			return $this->cli_error( __( 'Key could not be found in Migrate DB - this is not expected.', 'wp-sync-db-cli' ) );
+		}
+	}
+
 	function cli_create_profile( $name, $assoc_args ) {
 		$wpsdb_settings = get_option( 'wpsdb_settings' );
 

--- a/class/wpsdb-cli.php
+++ b/class/wpsdb-cli.php
@@ -11,7 +11,6 @@ class WPSDB_CLI extends WPSDB_Addon {
 	}
 
 	function cli_create_profile( $name, $assoc_args ) {
-		global $wpsdb;
 		$wpsdb_settings = get_option( 'wpsdb_settings' );
 
 		$profile_exists = false;

--- a/class/wpsdb-cli.php
+++ b/class/wpsdb-cli.php
@@ -28,8 +28,14 @@ class WPSDB_CLI extends WPSDB_Addon {
 
 		$new_profile = array();
 
-		$new_profile["create_new_profile"] = "Staging";
-		$new_profile["name"] = "Staging";
+		$new_profile["name"] = $name;
+		$new_profile["create_new_profile"] = $name;
+
+		$new_profile["action"] = "pull";
+
+		$new_profile['connection_info'] = implode( "\n", array( $assoc_args['remote_wordpress'], $assoc_args['token'] ) );
+
+		$new_profile["table_migrate_option"] = 'migrate_only_with_prefix';
 
 		// This is probably going to be a faff to do so leave it.
 		$new_profile["replace_old"] = array(
@@ -42,40 +48,53 @@ class WPSDB_CLI extends WPSDB_Addon {
 			"/app/web"
 		);
 
-		// This is all the tables in a standard Outlandish WordPress install we
-		// by default sync.
-		$new_profile["select_tables"] = array(
-			"wp_commentmeta",
-      "wp_comments",
-      "wp_links",
-      "wp_options",
-      "wp_p2p",
-      "wp_p2pmeta",
-      "wp_postmeta",
-      "wp_posts",
-      "wp_term_relationships",
-       "wp_term_taxonomy",
-      "wp_termmeta",
-      "wp_terms",
-      "wp_usermeta",
-      "wp_users",
-		);
-
 		$new_profile["save_computer"] = "1";
 		$new_profile["gzip_file"] = "1";
 		$new_profile["replace_guids"] = "1";
 		$new_profile["exclude_spam"] = "1";
 		$new_profile["keep_active_plugins"] = "1";
 		$new_profile["create_backup"] = "0";
-		$new_profile["exclude_post_types"] = "0";
-		$new_profile["action"] = "pull";
-		$new_profile["connection_info"] = "";
-		$new_profile["table_migrate_option"] = "migrate_select";
-		$new_profile["exclude_transients"] = "1";
 		$new_profile["backup_option"] = "backup_selected";
+
+		$new_profile["exclude_post_types"] = "0";
+		$new_profile["exclude_transients"] = "1";
 		$new_profile["media_files"] = "1";
+
 		$new_profile["save_migration_profile"] = "1";
 		$new_profile["save_migration_profile_option"] = "new";
+
+		$new_profile = array_merge( $new_profile, $assoc_args );
+
+		if ( isset( $assoc_args['select_tables'] ) ) {
+			$new_profile["table_migrate_option"] = 'migrate_select';
+
+			if ( $new_profile["select_tables"] === 'outlandish' ) {
+				WP_CLI::log(  __( 'Selecting Outlandish default WordPress tables for migraton.',  'wp-sync-db-cli' ) );
+				$new_profile["select_tables"] = array(
+					"wp_commentmeta",
+		      "wp_comments",
+		      "wp_links",
+		      "wp_options",
+		      "wp_p2p",
+		      "wp_p2pmeta",
+		      "wp_postmeta",
+		      "wp_posts",
+		      "wp_term_relationships",
+		       "wp_term_taxonomy",
+		      "wp_termmeta",
+		      "wp_terms",
+		      "wp_usermeta",
+		      "wp_users",
+				);
+			} else {
+				$new_profile["select_tables"] = explode( ',', $assoc_args['select_tables'] );
+				WP_CLI::log(  __( 'The following tables are selected for migration:',  'wp-sync-db-cli' ) );
+
+				foreach ( $new_profile["select_tables"] as $table ) {
+					WP_CLI::log( "- $table" );
+				}
+			}
+		}
 
 		$wpsdb_settings['profiles'][] = $new_profile;
 

--- a/class/wpsdb-cli.php
+++ b/class/wpsdb-cli.php
@@ -78,16 +78,12 @@ class WPSDB_CLI extends WPSDB_Addon {
 
 		$new_profile["table_migrate_option"] = 'migrate_only_with_prefix';
 
-		// This is probably going to be a faff to do so leave it.
-		$new_profile["replace_old"] = array(
-			"//staging.bprc.out.re",
-			"/opt/bprc/releases/20171002153612Z/web"
-		);
-
-		$new_profile["replace_new"] = array(
-			"//bprc.local",
-			"/app/web"
-		);
+		// This replacement is typically done by calling the other WordPress site all
+		// retrieving its variables.
+		//
+		// For the moment this is a TODO
+		$new_profile["replace_old"] = array();
+		$new_profile["replace_new"] = array();
 
 		$new_profile["save_computer"] = "1";
 		$new_profile["gzip_file"] = "1";

--- a/class/wpsdb-cli.php
+++ b/class/wpsdb-cli.php
@@ -10,6 +10,81 @@ class WPSDB_CLI extends WPSDB_Addon {
 		if( ! $this->meets_version_requirements( '1.4b1' ) ) return;
 	}
 
+	function cli_create_profile( $name, $assoc_args ) {
+		global $wpsdb;
+		$wpsdb_settings = get_option( 'wpsdb_settings' );
+
+		$profile_exists = false;
+
+		foreach ( $wpsdb_settings['profiles'] as $profile ) {
+			if ( $profile['name'] === $name ) {
+				$profile_exists = true;
+				break;
+			}
+		}
+
+		if ( $profile_exists ) {
+			return $this->cli_error( sprintf( __( 'Profile with the name %1$s already exists.', 'wp-sync-db-cli' ), $name ) );
+		}
+
+		$new_profile = array();
+
+		$new_profile["create_new_profile"] = "Staging";
+		$new_profile["name"] = "Staging";
+
+		// This is probably going to be a faff to do so leave it.
+		$new_profile["replace_old"] = array(
+			"//staging.bprc.out.re",
+			"/opt/bprc/releases/20171002153612Z/web"
+		);
+
+		$new_profile["replace_new"] = array(
+			"//bprc.local",
+			"/app/web"
+		);
+
+		// This is all the tables in a standard Outlandish WordPress install we
+		// by default sync.
+		$new_profile["select_tables"] = array(
+			"wp_commentmeta",
+      "wp_comments",
+      "wp_links",
+      "wp_options",
+      "wp_p2p",
+      "wp_p2pmeta",
+      "wp_postmeta",
+      "wp_posts",
+      "wp_term_relationships",
+       "wp_term_taxonomy",
+      "wp_termmeta",
+      "wp_terms",
+      "wp_usermeta",
+      "wp_users",
+		);
+
+		$new_profile["save_computer"] = "1";
+		$new_profile["gzip_file"] = "1";
+		$new_profile["replace_guids"] = "1";
+		$new_profile["exclude_spam"] = "1";
+		$new_profile["keep_active_plugins"] = "1";
+		$new_profile["create_backup"] = "0";
+		$new_profile["exclude_post_types"] = "0";
+		$new_profile["action"] = "pull";
+		$new_profile["connection_info"] = "";
+		$new_profile["table_migrate_option"] = "migrate_select";
+		$new_profile["exclude_transients"] = "1";
+		$new_profile["backup_option"] = "backup_selected";
+		$new_profile["media_files"] = "1";
+		$new_profile["save_migration_profile"] = "1";
+		$new_profile["save_migration_profile_option"] = "new";
+
+		$wpsdb_settings['profiles'][] = $new_profile;
+
+		update_option( 'wpsdb_settings', $wpsdb_settings );
+
+		return true;
+	}
+
 	function cli_migration( $profile ) {
 		global $wpsdb;
 		$wpsdb_settings = get_option( 'wpsdb_settings' );

--- a/class/wpsdb-cli.php
+++ b/class/wpsdb-cli.php
@@ -115,29 +115,9 @@ class WPSDB_CLI extends WPSDB_Addon {
 		if ( isset( $assoc_args['migrate-tables'] ) ) {
 			$new_profile["table_migrate_option"] = 'migrate_select';
 
-			if ( $new_profile["migrate-tables"] === 'outlandish' ) {
-				WP_CLI::log(  __( 'Selecting Outlandish default WordPress tables for migraton.',  'wp-sync-db-cli' ) );
-				$new_profile["select_tables"] = array(
-					"wp_commentmeta",
-		      "wp_comments",
-		      "wp_links",
-		      "wp_options",
-		      "wp_p2p",
-		      "wp_p2pmeta",
-		      "wp_postmeta",
-		      "wp_posts",
-		      "wp_term_relationships",
-		       "wp_term_taxonomy",
-		      "wp_termmeta",
-		      "wp_terms",
-		      "wp_usermeta",
-		      "wp_users",
-				);
-			} else {
-				$new_profile["select_tables"] = explode( ',', $assoc_args['migrate-tables'] );
-				WP_CLI::log(  __( 'The following tables are selected for migration:',  'wp-sync-db-cli' ) );
-				$this->log_list( $new_profile["select_tables"] );
-			}
+			$new_profile["select_tables"] = explode( ',', $assoc_args['migrate-tables'] );
+			WP_CLI::log(  __( 'The following tables are selected for migration:',  'wp-sync-db-cli' ) );
+			$this->log_list( $new_profile["select_tables"] );
 		}
 
 		$wpsdb_settings['profiles'][] = $new_profile;

--- a/class/wpsdb-cli.php
+++ b/class/wpsdb-cli.php
@@ -16,10 +16,25 @@ class WPSDB_CLI extends WPSDB_Addon {
 		}
 	}
 
-	function kebab_case_to_snake_case($value) {
+	function kebab_case_to_snake_case( $value ) {
 		return preg_replace_callback('/-(.)/u', function($el) {
 			return '_' . $el[1];
 		}, $value);
+	}
+
+	function values_as_booleans_to_one_and_zero_strings( $array ) {
+		$result = [];
+
+		foreach ($array as $key => $value) {
+			if ( $value === 'true' || $value === 'false' ) {
+				$result[$key] = (string)(int)($value === 'true');
+				continue;
+			}
+
+			$result[$key] = $value;
+		}
+
+		return $result;
 	}
 
 	function keys_from_kebab_case_to_snake_case( $array ) {
@@ -89,7 +104,9 @@ class WPSDB_CLI extends WPSDB_Addon {
 		$new_profile["save_migration_profile"] = "1";
 		$new_profile["save_migration_profile_option"] = "new";
 
-		$new_profile = array_merge( $new_profile, $this->keys_from_kebab_case_to_snake_case( $assoc_args ) );
+		$values_for_wordpress = $this->keys_from_kebab_case_to_snake_case( $assoc_args );
+		$values_for_wordpress = $this->values_as_booleans_to_one_and_zero_strings( $values_for_wordpress );
+		$new_profile = array_merge( $new_profile, $values_for_wordpress );
 
 		if ( isset( $assoc_args['exclude-post-types'] ) ) {
 			$new_profile['exclude_post_types'] = '1';
@@ -128,7 +145,6 @@ class WPSDB_CLI extends WPSDB_Addon {
 		}
 
 		$wpsdb_settings['profiles'][] = $new_profile;
-
 		update_option( 'wpsdb_settings', $wpsdb_settings );
 
 		return true;

--- a/class/wpsdb-cli.php
+++ b/class/wpsdb-cli.php
@@ -60,10 +60,10 @@ class WPSDB_CLI extends WPSDB_Addon {
 		}
 
 		if ( $profile_exists ) {
-			return $this->cli_error( sprintf( __( 'Profile with the name %1$s already exists.', 'wp-sync-db-cli' ), $name ) );
+			return $this->cli_error( sprintf( __( 'Profile with the name \'%1$s\' already exists.', 'wp-sync-db-cli' ), $name ) );
 		}
 
-		WP_CLI::log(  sprintf( __( 'Creating database migration profile with name %1$s.', 'wp-sync-db-cli' ), $name ) );
+		WP_CLI::log(  sprintf( __( 'Creating database migration profile with name \'%1$s\'.', 'wp-sync-db-cli' ), $name ) );
 
 		$new_profile = array();
 

--- a/wp-sync-db-cli.php
+++ b/wp-sync-db-cli.php
@@ -37,6 +37,14 @@ function wpsdb_migrate( $profile ) {
 	return $wpsdb_cli->cli_migration( $profile );
 }
 
+function wpsdb_cli_connection_info() {
+	global $wpsdb_cli;
+	if( empty( $wpsdb_cli ) ) {
+		return new WP_Error( 'wpsdb_cli_error', __( 'WP Sync DB CLI class not available', 'wp-sync-db-cli' ) );
+	}
+	return $wpsdb_cli->cli_connection_info();
+}
+
 function wpdsb_create_profile( $name, $assoc_args ) {
 	global $wpsdb_cli;
 	if( empty( $wpsdb_cli ) ) {

--- a/wp-sync-db-cli.php
+++ b/wp-sync-db-cli.php
@@ -36,3 +36,11 @@ function wpsdb_migrate( $profile ) {
 	}
 	return $wpsdb_cli->cli_migration( $profile );
 }
+
+function wpdsb_create_profile( $name, $assoc_args ) {
+	global $wpsdb_cli;
+	if( empty( $wpsdb_cli ) ) {
+		return new WP_Error( 'wpsdb_cli_error', __( 'WP Sync DB CLI class not available', 'wp-sync-db-cli' ) );
+	}
+	return $wpsdb_cli->cli_create_profile( $name, $assoc_args );
+}


### PR DESCRIPTION
This adds support for adding profiles with the following command.
```
wp wpsdb create-profile Staging --remote-wordpress https://wordpress.example --token CUOu2t5kaVienGLUxAGhN4bvWh1FXqJA
```

It adds a bunch more options as well - see the source code.